### PR TITLE
Updated Version, Corrected SBT Deprecations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,10 +42,10 @@ sonatypeProfileName := "io.verizon"
 pomPostProcess := { identity }
 
 addSbtPlugin("com.github.gseitz" % "sbt-release"   % "1.0.4")
-addSbtPlugin("com.timushev.sbt"  % "sbt-updates"   % "0.1.8")
-addSbtPlugin("com.eed3si9n"      % "sbt-buildinfo" % "0.5.0")
+addSbtPlugin("com.timushev.sbt"  % "sbt-updates"   % "0.3.1")
+addSbtPlugin("com.eed3si9n"      % "sbt-buildinfo" % "0.7.0")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage" % "1.5.0")
-addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"  % "1.1")
-addSbtPlugin("com.jsuereth"      % "sbt-pgp"       % "1.0.0")
+addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"  % "2.0")
+addSbtPlugin("com.jsuereth"      % "sbt-pgp"       % "1.1.0-M1")
 
 addCommandAlias("validate", ";test;scripted")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.16-M1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 
-libraryDependencies <+= (sbtVersion) { sv =>
-  "org.scala-sbt" % "scripted-plugin" % sv
-}
+libraryDependencies ++= Seq(
+  "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
+)
 
-addSbtPlugin("io.verizon.build" % "sbt-rig" % "1.1.20")
+addSbtPlugin("io.verizon.build" % "sbt-rig" % "2.0.30")

--- a/src/main/scala/Specs2Plugin.scala
+++ b/src/main/scala/Specs2Plugin.scala
@@ -27,14 +27,15 @@ object Specs2Plugin extends AutoPlugin {
 
   override def trigger = noTrigger
 
-  override lazy val projectSettings = Seq(
-    specs2version := "3.6.1",
-    libraryDependencies <++= (specs2version) { v =>
-      Seq(
-        "org.specs2" %% "specs2-core" % v % "test",
-        "org.specs2" %% "specs2-junit" % v % "test"
-      )
-    },
-    testOptions in Test += Tests.Argument(TestFrameworks.Specs2, "junitxml", "console")
-  )
+  override lazy val projectSettings = {
+    val specs2V = "3.9.0"
+    Seq(
+      specs2version := specs2V,
+      libraryDependencies ++= Seq(
+        "org.specs2" %% "specs2-core" % specs2V % "test",
+        "org.specs2" %% "specs2-junit" % specs2V % "test"
+      ),
+      testOptions in Test += Tests.Argument(TestFrameworks.Specs2, "junitxml", "console")
+    )
+  }
 }


### PR DESCRIPTION
Since I was taking a shot at a single hard one I figured I would clear out the herd and update so that you are ready to go. Most were no mess. Sbt Updates needed to clear out deprecated syntax.

I applied your dogfood so that you were up to your own current release on this. 

Looks like the values being exposed in 1.0 are actually going to make it much easier so there are less option.get hacks to pull settings values through. 
