### PR TITLE
Revert "Update for sbt-release 1.0.5"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ project/boot/
 project/plugins/project/
 .DS_Store
 gpg.sbt
-.idea/

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ pomPostProcess := { identity }
 
 addSbtPlugin("com.eed3si9n"      % "sbt-buildinfo" % "0.7.0")
 addSbtPlugin("com.eed3si9n"      % "sbt-unidoc"    % "0.4.0")
-addSbtPlugin("com.github.gseitz" % "sbt-release"   % "1.0.5")
+addSbtPlugin("com.github.gseitz" % "sbt-release"   % "1.0.4")
 addSbtPlugin("com.jsuereth"      % "sbt-pgp"       % "1.0.0")
 addSbtPlugin("com.timushev.sbt"  % "sbt-updates"   % "0.3.1")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-ghpages"   % "0.6.0")


### PR DESCRIPTION
This reverts commit 877be067c0925178853406b66033999ce2fa80e1. It's interpreting
releases as snapshots.  1.0.4 -> 1.0.5 was a deceptively large upgrade.