### PR TITLE
Roll back to sbt-sonatype-1.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,6 +50,6 @@ addSbtPlugin("com.typesafe.sbt"  % "sbt-ghpages"   % "0.6.0")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-site"      % "1.2.0")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage" % "1.5.0")
 addSbtPlugin("org.tpolecat"      % "tut-plugin"    % "0.5.2")
-addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"  % "2.0")
+addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"  % "1.1")
 
 addCommandAlias("validate", ";test;scripted")


### PR DESCRIPTION
Right now, rig is publishing to one staging repo and closing another (empty)
one. The last time we published successfully with rig, we were on 1.1. This will
establish whether it was the upgrade or something else.