### PR TITLE
Don't publish instrumented code; fix test plugins

### DIFF
--- a/src/main/scala/ScalaCheckPlugin.scala
+++ b/src/main/scala/ScalaCheckPlugin.scala
@@ -30,7 +30,7 @@ object ScalaCheckPlugin extends AutoPlugin {
   override lazy val projectSettings = Seq(
     scalaCheckVersion := "1.13.5",
     libraryDependencies ++= Seq(
-      "org.scalatest"  %% "scalatest"  % scalaCheckVersion.value  % "test"
+      "org.scalacheck"  %% "scalacheck"  % scalaCheckVersion.value  % "test"
     )
   )
 }

--- a/src/main/scala/Specs2Plugin.scala
+++ b/src/main/scala/Specs2Plugin.scala
@@ -30,15 +30,12 @@ object Specs2Plugin extends AutoPlugin {
 
   override def trigger = noTrigger
 
-  override lazy val projectSettings = {
-    val specs2V = "3.9.0"
-    Seq(
-      specs2version := specs2V,
-      libraryDependencies ++= Seq(
-        "org.specs2" %% "specs2-core" % specs2V % "test",
-        "org.specs2" %% "specs2-junit" % specs2V % "test"
-      ),
-      testOptions in Test += Tests.Argument(TestFrameworks.Specs2, "junitxml", "console")
-    )
-  }
+  override lazy val projectSettings = Seq(
+    specs2version := "3.9.0",
+    libraryDependencies ++= Seq(
+      "org.specs2" %% "specs2-core" % specs2version.value % "test",
+      "org.specs2" %% "specs2-junit" % specs2version.value % "test"
+    ),
+    testOptions in Test += Tests.Argument(TestFrameworks.Specs2, "junitxml", "console")
+  )
 }


### PR DESCRIPTION
The second pass was rebuilding the code, but not turning off instrumentation.  We move the coverage settings to build settings instead of project settings.  This is compatible with `coverageOn` and `coverageOff` commands, and lets us disable instrumentation on the second pass.  This pulls along the Travis settings, which all should also apply to the build.

Another fix is to compose the `pomPostProcess` with the old value in the unlikely event that another plugin that runs before us is customizing the pom.

Meanwhile, while testing this on helm, I discovered the scalacheck and specs2 plugins were broken.  Those come along for the ride.
