### PR TITLE
Publish code without instrumentation, take 2

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.0.0-SNAPSHOT"
+version in ThisBuild := "4.0.0-SNAPSHOT"


### PR DESCRIPTION
- runs with coverage by default in Travis.  We previously turned on coverage,
  didn't generate the reports, turned it off, rebuilt, and accidentally turned
  it on again to build the binaries.  These were bad things.
- create a publishArtifactsWithoutInstrumentation release step that explicitly
  turns off coverage before running the publish release step.  This forces a
  recompilation without instrumentation where necessary.
- sets scala version to TRAVIS_SCALA_VERSION in compilation settings, which
  avoids some settingrot later
- removes useTravisScalaVersion hack