### PR TITLE
SBT 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 
 scala:
-  - 2.10.5
+  - 2.10.6
 
 jdk:
   - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -127,3 +127,13 @@ In addition, the following plugins are provided by `sbt-rig`, but are not explic
   </tbody>
 </table>
 
+## Migration notes
+
+### v5.0
+
+* Built for sbt-1.0.  Bump `sbt.version` in `project/build.properties` to at least `1.0.1`.
+* `scalacOptions` are no longer set, as they are unrelated to releasing software.  We recommend [sbt-tpolecat](https://github.com/DavidGregory084/sbt-tpolecat) for setting a reasonable set of compiler options for your version of Scala.
+* Coverage highlighting is now enabled by default above Scala 2.11.1
+* Unified `turnOffCoverage` and `publishArtifacsWithoutInstrumentation` [sic] release steps into `publishToSonatypeWithoutInstrumentation`.  If you did not customize the release steps previously, there is nothing new to do.
+* `watchSources` customization is removed, as we can no longer filter out the target directory.
+* Theoretically can be used without git if you don't use the DocsPlugin with sbt-ghpages, though I don't know anybody who has tried.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ In addition, the following plugins are provided by `sbt-rig`, but are not explic
 ### v5.0
 
 * Built for sbt-1.0.  Bump `sbt.version` in `project/build.properties` to at least `1.0.1`.
-* `scalacOptions` are no longer set, as they are unrelated to releasing software.  We recommend [sbt-tpolecat](https://github.com/DavidGregory084/sbt-tpolecat) for setting a reasonable set of compiler options for your version of Scala.
+* `scalacOptions` are now set by [sbt-tpolecat](https://github.com/DavidGregory084/sbt-tpolecat), a stricter but better set than was available in sbt-rig-4.x.  Opt out of disagreeable flags with `scalacOptions -= ...`.
+* Uses [sbt-partial-unification](https://github.com/fiadliel/sbt-partial-unification).  If on Scala 2.10, upgrade to at least Scala 2.10.6.  If on Scala 2.11, upgrade to at least Scala 2.11.8.
 * Coverage highlighting is now enabled by default above Scala 2.11.1
 * Unified `turnOffCoverage` and `publishArtifacsWithoutInstrumentation` [sic] release steps into `publishToSonatypeWithoutInstrumentation`.  If you did not customize the release steps previously, there is nothing new to do.
 * `watchSources` customization is removed, as we can no longer filter out the target directory.

--- a/build.sbt
+++ b/build.sbt
@@ -41,24 +41,25 @@ sonatypeProfileName := "io.verizon"
 
 pomPostProcess := { identity }
 
-scalaVersion := "2.12.2"
+scalaVersion := "2.12.3"
 
-sbtVersion in Global := "1.0.1"
+sbtVersion in Global := "1.0.2"
 
 scalaCompilerBridgeSource := {
   val sv = appConfiguration.value.provider.id.version
     ("org.scala-sbt" % "compiler-interface" % sv % "component").sources
 }
 
-addSbtPlugin("com.eed3si9n"      % "sbt-buildinfo" % "0.7.0")
-addSbtPlugin("com.eed3si9n"      % "sbt-unidoc"    % "0.4.1")
-addSbtPlugin("com.github.gseitz" % "sbt-release"   % "1.0.6")
-addSbtPlugin("com.jsuereth"      % "sbt-pgp"       % "1.1.0")
-addSbtPlugin("com.timushev.sbt"  % "sbt-updates"   % "0.3.1")
-addSbtPlugin("com.typesafe.sbt"  % "sbt-ghpages"   % "0.6.2")
-addSbtPlugin("com.typesafe.sbt"  % "sbt-site"      % "1.3.0")
-addSbtPlugin("org.scoverage"     % "sbt-scoverage" % "1.5.1")
-addSbtPlugin("org.tpolecat"      % "tut-plugin"    % "0.6.0")
-addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"  % "2.0")
+addSbtPlugin("com.eed3si9n"              % "sbt-buildinfo" % "0.7.0")
+addSbtPlugin("com.eed3si9n"              % "sbt-unidoc"    % "0.4.1")
+addSbtPlugin("com.github.gseitz"         % "sbt-release"   % "1.0.6")
+addSbtPlugin("com.jsuereth"              % "sbt-pgp"       % "1.1.0")
+addSbtPlugin("com.timushev.sbt"          % "sbt-updates"   % "0.3.1")
+addSbtPlugin("com.typesafe.sbt"          % "sbt-ghpages"   % "0.6.2")
+addSbtPlugin("com.typesafe.sbt"          % "sbt-site"      % "1.3.0")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"  % "0.1.3")
+addSbtPlugin("org.scoverage"             % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("org.tpolecat"              % "tut-plugin"    % "0.6.0")
+addSbtPlugin("org.xerial.sbt"            % "sbt-sonatype"  % "2.0")
 
 addCommandAlias("validate", ";test;scripted")

--- a/build.sbt
+++ b/build.sbt
@@ -41,15 +41,24 @@ sonatypeProfileName := "io.verizon"
 
 pomPostProcess := { identity }
 
+scalaVersion := "2.12.2"
+
+sbtVersion in Global := "1.0.1"
+
+scalaCompilerBridgeSource := {
+  val sv = appConfiguration.value.provider.id.version
+    ("org.scala-sbt" % "compiler-interface" % sv % "component").sources
+}
+
 addSbtPlugin("com.eed3si9n"      % "sbt-buildinfo" % "0.7.0")
-addSbtPlugin("com.eed3si9n"      % "sbt-unidoc"    % "0.4.0")
-addSbtPlugin("com.github.gseitz" % "sbt-release"   % "1.0.4")
-addSbtPlugin("com.jsuereth"      % "sbt-pgp"       % "1.0.0")
+addSbtPlugin("com.eed3si9n"      % "sbt-unidoc"    % "0.4.1")
+addSbtPlugin("com.github.gseitz" % "sbt-release"   % "1.0.6")
+addSbtPlugin("com.jsuereth"      % "sbt-pgp"       % "1.1.0")
 addSbtPlugin("com.timushev.sbt"  % "sbt-updates"   % "0.3.1")
-addSbtPlugin("com.typesafe.sbt"  % "sbt-ghpages"   % "0.6.0")
-addSbtPlugin("com.typesafe.sbt"  % "sbt-site"      % "1.2.1")
-addSbtPlugin("org.scoverage"     % "sbt-scoverage" % "1.5.0")
-addSbtPlugin("org.tpolecat"      % "tut-plugin"    % "0.5.2")
-addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"  % "1.1")
+addSbtPlugin("com.typesafe.sbt"  % "sbt-ghpages"   % "0.6.2")
+addSbtPlugin("com.typesafe.sbt"  % "sbt-site"      % "1.3.0")
+addSbtPlugin("org.scoverage"     % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("org.tpolecat"      % "tut-plugin"    % "0.6.0")
+addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"  % "2.0")
 
 addCommandAlias("validate", ";test;scripted")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,4 @@ libraryDependencies ++= Seq(
   "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
 )
 
-addSbtPlugin("io.verizon.build" % "sbt-rig" % "2.0.30")
+addSbtPlugin("io.verizon.build" % "sbt-rig" % "4.0.36")

--- a/src/main/scala/DocsPlugin.scala
+++ b/src/main/scala/DocsPlugin.scala
@@ -87,12 +87,12 @@ object DocsPlugin extends AutoPlugin { self =>
       preStageSiteDirectory := sourceDirectory.value / "hugo",
       siteStageDirectory := target.value / "site-stage",
       sourceDirectory in Hugo := siteStageDirectory.value,
-      watchSources := {
-        // nasty hack to remove the target directory from watched sources
-        watchSources.value
-          .filterNot(_.getAbsolutePath.startsWith(
-            target.value.getAbsolutePath))
-      },
+      // watchSources := {
+      //   // nasty hack to remove the target directory from watched sources
+      //   watchSources.value
+      //     .filterNot(_.getAbsolutePath.startsWith(
+      //       target.value.getAbsolutePath))
+      // },
       copySiteToStage := {
         streams.value.log.debug(s"copying ${preStageSiteDirectory.value} to ${siteStageDirectory.value}")
 

--- a/src/main/scala/RigPlugin.scala
+++ b/src/main/scala/RigPlugin.scala
@@ -91,52 +91,8 @@ object common {
         username, password)).toSeq
   )
 
-  def compilationSettings = {
-    val flags = Seq(
-      "-deprecation",
-      "-encoding", "UTF-8",
-      "-unchecked",
-      "-feature",
-      "-language:implicitConversions",
-      "-language:higherKinds",
-      "-Ywarn-adapted-args",
-      "-Ywarn-dead-code",
-      "-Ywarn-inaccessible",
-      "-Xfatal-warnings",
-      "-Xfuture",
-      "-Xmax-classfile-name", (255 - 15).toString
-    )
-
-    Seq(
-      scalacOptions in Compile ++= (CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, 10)) => flags ++ Seq("-Xlint", "-Ywarn-value-discard")
-        case Some((2, n)) if n >= 11 => flags ++ Seq(
-          "-Xlint:adapted-args",
-          "-Xlint:nullary-unit",
-          "-Xlint:inaccessible",
-          "-Xlint:nullary-override",
-          "-Xlint:missing-interpolator",
-          "-Xlint:doc-detached",
-          "-Xlint:private-shadow",
-          "-Xlint:type-parameter-shadow",
-          "-Xlint:poly-implicit-overload",
-          "-Xlint:option-implicit",
-          "-Xlint:delayedinit-select",
-          "-Xlint:by-name-right-associative",
-          "-Xlint:package-object-classes",
-          "-Xlint:unsound-match",
-          "-Xlint:stars-align"
-        ) ++ (
-          if(n >= 12) {
-            Seq("-Ypartial-unification")
-          } else {
-            Seq()
-          }
-        )
-      }),
-      scalacOptions in Test := (scalacOptions in Compile).value :+ "-language:reflectiveCalls"
-    ) ++ sys.env.get("TRAVIS_SCALA_VERSION").map(scalaVersion := _)
-  }
+  def compilationSettings =
+    sys.env.get("TRAVIS_SCALA_VERSION").toList.map(scalaVersion := _)
 
   def coverageSettings = Seq(
     coverageFailOnMinimum := false,

--- a/src/main/scala/RigPlugin.scala
+++ b/src/main/scala/RigPlugin.scala
@@ -145,14 +145,16 @@ object common {
       isTravisBuild.value
     },
     coverageHighlighting := {
-      isTravisBuild.value && scalaVersion.value.startsWith("2.11")
+      // https://github.com/scoverage/sbt-scoverage#highlighting
+      val VersionNumber((major +: minor +: patch +: _), _, _) = scalaVersion.value
+      import scala.math.Ordered.orderingToOrdered
+      ((major, minor, patch)) > ((2, 11, 1))
     }
   )
 
   import sbtrelease._
-  import sbtrelease.ReleasePlugin.autoImport._
+  import sbtrelease.ReleasePlugin.autoImport._, ReleasePlugin.runtimeVersion
   import sbtrelease.ReleaseStateTransformations._
-  import sbtrelease.Utilities._
 
   def checkEnvironment(slug: Option[String], bn: Option[String]) =
     ReleaseStep(action = st => {
@@ -250,7 +252,7 @@ object common {
         .orElse(Version(ver).map(_.withoutQualifier.string))
         .getOrElse(versionFormatError)
     },
-    releaseTagName := runtimeVersion.value // 'Round these parts, we don't add the "v" prefix
+    releaseTagName := runtimeVersion.value, // 'Round these parts, we don't add the "v" prefix
     releaseProcess := Seq(
       Seq[ReleaseStep](
         checkEnvironment(travisRepoSlug.value, travisBuildNumber.value),

--- a/src/main/scala/RigPlugin.scala
+++ b/src/main/scala/RigPlugin.scala
@@ -190,7 +190,7 @@ object common {
     val thisRef = ex1.get(thisProjectRef)
     val repoId = (sonatypeStagingRepositoryProfile in thisRef).get(ex1.structure.data).get.repositoryId
     state.log.info(s"Closing staging repo ${repoId}")
-    releaseStepCommand(s"sonatypeDrop $repoId")(state)
+    releaseStepCommand(s"sonatypeRelease $repoId")(state)
   })
 
   import com.typesafe.sbt.SbtPgp.autoImport._, PgpKeys._

--- a/src/main/scala/RigPlugin.scala
+++ b/src/main/scala/RigPlugin.scala
@@ -139,8 +139,6 @@ object common {
   }
 
   def coverageSettings = Seq(
-    /* don't delete the coverage data, so we have it to upload later */
-    // cleanKeepFiles += crossTarget.value / "scoverage-data",
     coverageFailOnMinimum := false,
     coverageEnabled := {
       /* if we're running on travis, use coverage, don't otherwise */
@@ -148,19 +146,6 @@ object common {
     },
     coverageHighlighting := {
       isTravisBuild.value && scalaVersion.value.startsWith("2.11")
-    },
-    // Without this, scoverage shows up as a dependency in the POM file.
-    // See https://github.com/scoverage/sbt-scoverage/issues/153.
-    // This code was borrowed from https://github.com/mongodb/mongo-spark.
-    pomPostProcess ~= { ppp => (node: xml.Node) =>
-      new RuleTransformer(
-        new RewriteRule {
-          override def transform(node: xml.Node): Seq[xml.Node] = node match {
-            case e: xml.Elem
-                if e.label == "dependency" && e.child.exists(child => child.label == "groupId" && child.text == "org.scoverage") => Nil
-            case _ => Seq(node)
-          }
-        }).transform(ppp(node)).head
     }
   )
 
@@ -186,12 +171,12 @@ object common {
     check = { st =>
       val extracted = Project.extract(st)
       val v = extracted.get(Keys.version)
-      val rf = extracted.get(releaseVersion)
+      val (st1, rf) = extracted.runTask(releaseVersion, st)
       val actualVersion = rf(v)
       Version(actualVersion).filter(v =>
         v.qualifier.forall(_.isEmpty) && v.subversions.size == 2
       ).getOrElse(sys.error(s"version $v does not match the expected pattern of x.y.z where x, y, and z are all integers."))
-      st
+      st1
     })
 
   val runTestWithCoverage: ReleaseStep = ReleaseStep(action = state1 => {
@@ -207,26 +192,28 @@ object common {
     state3
   })
 
-  /** Forcibly disable coverage on all projects. `coverageOff` just disables
-    * `coverageEnabled in ThisBuild``, but leaves coverage on projects
-    * explicitly opted in. This forcibly removes it, and should be run before we
-    * publish.
+  /** Forcibly turns off coverage on all projects, sets publishTo to the
+    * open sonatype repository, and invokes `publishArtifacts`.
     */
-  val turnOffCoverage = ReleaseStep { state =>
+  val publishToSonatypeWithoutInstrumentation: ReleaseStep = ReleaseStep { state =>
     val ex = Project.extract(state)
-    reapply(ex.structure.allProjectRefs.map { proj =>
-      coverageEnabled in proj := false
-    }, state)}
-
-  /** Some release steps can undo turning off coverage.  In the case of rig's
-   *  default settings, sonatypeOpen turns coverage back on.  This step turns
-   *  off coverage just before publishing, which will ensure that we don't
-   *  publish instrumented code
-   */
-  val publishArtifacsWithoutInstrumentation: ReleaseStep =
-    publishArtifacts.copy(
-      action = turnOffCoverage.action andThen publishArtifacts.action
-    )
+    val thisRef = ex.get(thisProjectRef)
+    // This does too much, but each call to reapply discards the rest of the release
+    // settings.  We've apparently only got one bite at this apple.
+    val state1 = reapply(ex.structure.allProjectRefs.flatMap { proj =>
+      val repo = (sonatypeStagingRepositoryProfile in thisRef).get(ex.structure.data).get
+      val path = "/staging/deployByRepositoryId/"+repo.repositoryId
+      // This disappears if we don't propagate it. :(
+      (sonatypeStagingRepositoryProfile in proj := repo) +:
+      Seq(
+        // As of sbt-sonatype-2.0, we're on our own to set this
+        publishTo in proj := Some(MavenRepository(repo.repositoryId, sonatypeRepository.value + path)),
+        // Never, ever, ever publish with instrumentation
+        coverageEnabled in proj := false
+      )
+    }, state)
+    publishArtifacts.action(state1)
+  }
 
   /** Opens a sonatype repo.  We open one explicitly so concurrent builds in
    *  the same organization to not publish to the same staging repo and
@@ -237,31 +224,22 @@ object common {
     val thisRef = ex.get(thisProjectRef)
     val slug = (travisRepoSlug in thisRef).get(ex.structure.data).flatten
     val jobNumber = (travisJobNumber in thisRef).get(ex.structure.data).flatten
-    val state1 = Command.process(s"sonatypeOpen ${slug.getOrElse("unknown")}-${jobNumber.getOrElse("0.0")}", state)
-
-    val ex1 = Project.extract(state1)
-    val thisRef1 = ex1.get(thisProjectRef)
-    reapply(ex1.structure.allProjectRefs.flatMap { proj => Seq(
-      publishTo in proj := (publishTo in thisRef1).get(ex1.structure.data).get,
-      sonatypeStagingRepositoryProfile in proj := (sonatypeStagingRepositoryProfile in thisRef).get(ex1.structure.data).get
-    )}, state)
+    releaseStepCommand(s"sonatypeOpen ${slug.getOrElse("unknown")}-${jobNumber.getOrElse("0.0")}")(state)
   }
 
-  val releaseAndClose: ReleaseStep = ReleaseStep(action = state1 => {
-    val ex1 = Project.extract(state1)
+  val releaseAndClose: ReleaseStep = ReleaseStep(action = state => {
+    val ex1 = Project.extract(state)
     val thisRef = ex1.get(thisProjectRef)
     val repoId = (sonatypeStagingRepositoryProfile in thisRef).get(ex1.structure.data).get.repositoryId
-
-    Command.process(s"sonatypeRelease $repoId", state1)
+    state.log.info(s"Closing staging repo ${repoId}")
+    releaseStepCommand(s"sonatypeDrop $repoId")(state)
   })
 
   import com.typesafe.sbt.SbtPgp.autoImport._, PgpKeys._
 
   def releaseSettings = Seq(
-    sonatypeStagingRepositoryProfile := Sonatype.StagingRepositoryProfile("unknown","unknown","unknown","unknown","unknown"),
     releasePublishArtifactsAction := publishSigned.value,
     releaseCrossBuild := false,
-    releaseVcs := Some(new GitX(baseDirectory.value)), // only work with Git, sorry SVN people.
     releaseVersion := { ver =>
       travisBuildNumber.value.orElse(sys.env.get("BUILD_NUMBER"))
         .flatMap(s => try Option(s.toInt) catch { case _: NumberFormatException => Option.empty[Int] })
@@ -272,7 +250,7 @@ object common {
         .orElse(Version(ver).map(_.withoutQualifier.string))
         .getOrElse(versionFormatError)
     },
-    releaseTagName := s"${if (releaseUseGlobalVersion.value) (version in ThisBuild).value else version.value}",
+    releaseTagName := runtimeVersion.value // 'Round these parts, we don't add the "v" prefix
     releaseProcess := Seq(
       Seq[ReleaseStep](
         checkEnvironment(travisRepoSlug.value, travisBuildNumber.value),
@@ -283,8 +261,8 @@ object common {
         tagRelease,
         runTestWithCoverage,
         openSonatypeRepo,
-        publishArtifacsWithoutInstrumentation,
-        releaseAndClose
+        publishToSonatypeWithoutInstrumentation,
+        releaseAndClose,
       ),
       // only job *.1 pushes tags, to avoid each independent job attempting to retag the same release
       travisJobNumber.value

--- a/src/sbt-test/sbt-rig/packaging/project.sbt
+++ b/src/sbt-test/sbt-rig/packaging/project.sbt
@@ -1,6 +1,6 @@
 
 
-scalaVersion in Global  := "2.11.7"
+scalaVersion in Global  := "2.11.11"
 
 resolvers in Global += {
   val testRepoUri = baseDirectory.value.toURI + "/repo"

--- a/src/sbt-test/sbt-rig/packaging/test
+++ b/src/sbt-test/sbt-rig/packaging/test
@@ -1,1 +1,1 @@
-> publish-local
+> publishLocal

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "4.0.0-SNAPSHOT"
+version in ThisBuild := "5.0.0-SNAPSHOT"


### PR DESCRIPTION
* fix `coverageHighlighting` for Scala > 2.11
* unify `turnOffCoverage` and `publishArtifacsWithoutInstrumentation` [sic] into `publishToSonatypeWithoutInstrumentation`.
* don't mandate git, though I doubt anyone did otherwise
* remove `watchSources`, as we can no longer filter them
* set scalacOptions with sbt-tpolecat